### PR TITLE
Everything has been cut over to use new version of mongo!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ before_install:
 script:
   # Test doc samples.
   - cd wither && cargo +nightly-2018-10-09 test --features docinclude --doc; cd -
-  - cd wither_derive && cargo +nightly-2018-10-09 test --features docinclude --doc; cd -
+  - cd wither_derive && cargo +nightly-2018-10-09 test --doc; cd -
   # Test code generation & compilation.
-  - cargo +nightly-2018-10-09 test -p wither_derive --tests --lib
+  - cargo +nightly-2018-10-09 test -p wither_tests -p wither_derive --tests --lib
   # Test against MongoDB 3.2.
   - HOST=localhost PORT=27017 cargo test -p wither --tests --lib -- --test-threads=1
   # Test against MongoDB 3.4.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,8 +35,17 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "block-buffer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bson"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -51,6 +65,11 @@ dependencies = [
 [[package]]
 name = "bufstream"
 version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byte-tools"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -100,6 +119,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "crypto-mac"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +140,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "diff"
 version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "digest"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -134,9 +180,12 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "gcc"
-version = "0.3.55"
+name = "generic-array"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "getopts"
@@ -150,6 +199,15 @@ dependencies = [
 name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hmac"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crypto-mac 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "hostname"
@@ -194,6 +252,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "md5"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,20 +287,24 @@ dependencies = [
 
 [[package]]
 name = "mongodb"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bson 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bson 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "md-5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pbkdf2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "scan_fmt 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "separator 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha-1 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textnonce 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -251,8 +323,23 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "pbkdf2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crypto-mac 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proc-macro2"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -263,7 +350,7 @@ name = "quote"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -345,7 +432,7 @@ name = "regex-syntax"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -353,25 +440,8 @@ name = "regex-syntax"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "rust-crypto"
-version = "0.2.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ryu"
@@ -419,9 +489,9 @@ name = "serde_derive"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -433,6 +503,28 @@ dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sha2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -448,10 +540,10 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.20"
+version = "0.15.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -493,8 +585,13 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "typenum"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ucd-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -546,64 +643,69 @@ dependencies = [
 
 [[package]]
 name = "wither"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
- "bson 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mongodb 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mongodb 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "wither_derive 0.6.1",
+ "wither_derive 0.6.2",
 ]
 
 [[package]]
 name = "wither_derive"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "Inflector 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "bson 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "mongodb 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mongodb 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wither_tests"
 version = "0.0.0"
 dependencies = [
- "bson 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "compiletest_rs 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "mongodb 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mongodb 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
- "wither 0.6.2",
- "wither_derive 0.6.1",
+ "wither 0.6.3",
+ "wither_derive 0.6.2",
 ]
 
 [metadata]
 "checksum Inflector 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4467f98bb61f615f8273359bf1c989453dfc1ea4a45ae9298f1dcd0672febe5d"
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
+"checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
-"checksum bson 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ca9624b6599c91474a299f7ecf9adfc2d25e99f1a91bcb0abcbcf9f3dcd234d"
+"checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
+"checksum bson 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8984b7b33b1f8ac97468df3cefa76c7035abb0786473aa2a437dea0c72855702"
 "checksum bufstream 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
+"checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum compiletest_rs 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "89747fe073b7838343bd2c2445e7a7c2e0d415598f8925f0fa9205b9cdfc48cb"
+"checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
+"checksum crypto-mac 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7afa06d05a046c7a47c3a849907ec303504608c927f4e85f7bfff22b7180d971"
 "checksum data-encoding 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "67df0571a74bf0d97fb8b2ed22abdd9a48475c96bd327db968b7d9cace99655e"
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
+"checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
+"checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum filetime 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b3ea0c97183a611b1673e5e28b160d7e1035106cad053c988aae3bbd996fdcce"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+"checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0a7292d30132fb5424b354f5dc02512a86e4c516fe544bb7a25e7f266951b797"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+"checksum hmac 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "733e1b3ac906631ca01ebb577e9bb0f5e37a454032b9036b5eaea4013ed6f99a"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
@@ -611,13 +713,15 @@ dependencies = [
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum md-5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9402eaae33a9e144ce18ef488a0e4ca19869673c7bcdbbfe2030fdc3f84211cd"
 "checksum md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
 "checksum memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a3eb002f0535929f1199681417029ebea04aadc0c7a4224b46be99c7f5d6a16"
 "checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
-"checksum mongodb 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4408adb6bda6441f53eb96e389d9f64f18b7caadee889bcdccb771be9060897c"
+"checksum mongodb 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "d558c8c1ee6140954f82b53558135bb9ecb7b258e10dbd7206d985d134d388e0"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
-"checksum proc-macro2 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)" = "88dae56b29da695d783ea7fc5a90de281f79eb38407e77f6d674dd8befc4ac47"
+"checksum pbkdf2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0c09cddfbfc98de7f76931acf44460972edb4023eb14d0c6d4018800e552d8e0"
+"checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
@@ -629,8 +733,6 @@ dependencies = [
 "checksum regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ee84f70c8c08744ea9641a731c7fadb475bf2ecc52d7f627feb833e0b3990467"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"
-"checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
-"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum scan_fmt 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b87497427f9fbe539ee6b9626f5a5e899331fdf1c1d62f14c637a462969db30"
@@ -640,13 +742,16 @@ dependencies = [
 "checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
 "checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
 "checksum serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811"
+"checksum sha-1 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9d1f3b5de8a167ab06834a7c883bd197f2191e1dda1a22d9ccfeedbf9aded"
+"checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
-"checksum syn 0.15.20 (registry+https://github.com/rust-lang/crates.io-index)" = "8886c8d2774e853fcd7d9d2131f6e40ba46c9c0e358e4d57178452abd6859bb0"
+"checksum syn 0.15.21 (registry+https://github.com/rust-lang/crates.io-index)" = "816b7af21405b011a23554ea2dc3f6576dc86ca557047c34098c1d741f10f823"
 "checksum textnonce 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "df4033262e39249fc34cad20ce07fa03b8181e33e65d854ee1afb229b28974c6"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum try_from 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "923a7ee3e97dbfe8685261beb4511cc9620a1252405d02693d43169729570111"
-"checksum ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0f8bfa9ff0cadcd210129ad9d2c5f145c13e9ced3d3e5d948a6213487d52444"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ To get started, simply derive `Model` on your struct along with a few other serd
 // First, we add import statements for the crates that we need.
 // In Rust 2018, `extern crate` declarations will no longer be needed.
 #[macro_use]
-extern crate bson;
 extern crate mongodb;
 extern crate serde;
 #[macro_use(Serialize, Deserialize)]
@@ -36,11 +35,11 @@ extern crate wither;
 extern crate wither_derive;
 
 // Next we bring a few types into scope for our example.
-use bson::oid::ObjectId;
 use mongodb::{
     Client, ThreadedClient,
     db::{Database, ThreadedDatabase},
     coll::options::IndexModel,
+    oid::ObjectId,
 };
 use wither::prelude::*;
 

--- a/wither/Cargo.toml
+++ b/wither/Cargo.toml
@@ -9,10 +9,9 @@ license = "Apache-2.0"
 name = "wither"
 readme = "../README.md"
 repository = "https://github.com/thedodd/wither"
-version = "0.6.2"
+version = "0.6.3"
 
 [dependencies]
-bson = "0.12"
 chrono = "0.4"
 log = "0.4"
 mongodb = "0.3"

--- a/wither/docs/manually-implementing-model.md
+++ b/wither/docs/manually-implementing-model.md
@@ -5,7 +5,6 @@ section is for you. If not, feel free to skip over it.
 ### basic impl
 ```rust
 #[macro_use]
-extern crate bson;
 extern crate mongodb;
 extern crate serde;
 #[macro_use(Serialize, Deserialize)]
@@ -16,7 +15,7 @@ extern crate wither;
 pub struct User {
     /// The user's unique ID.
     #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
-    pub id: Option<bson::oid::ObjectId>,
+    pub id: Option<mongodb::oid::ObjectId>,
 
     /// The user's unique email.
     pub email: String,
@@ -28,12 +27,12 @@ impl<'a> wither::Model<'a> for User {
     const COLLECTION_NAME: &'static str = "users";
 
     /// Implement the getter for the ID of a model instance.
-    fn id(&self) -> Option<bson::oid::ObjectId> {
+    fn id(&self) -> Option<mongodb::oid::ObjectId> {
         return self.id.clone();
     }
 
     /// Implement the setter for the ID of a model instance.
-    fn set_id(&mut self, oid: bson::oid::ObjectId) {
+    fn set_id(&mut self, oid: mongodb::oid::ObjectId) {
         self.id = Some(oid);
     }
 }
@@ -45,7 +44,6 @@ To manually declare indexes, declare them in the `indexes` method.
 
 ```rust
 # #[macro_use]
-# extern crate bson;
 # extern crate mongodb;
 # extern crate serde;
 # #[macro_use(Serialize, Deserialize)]
@@ -58,7 +56,7 @@ use mongodb::coll::options::IndexModel;
 # pub struct User {
 #     /// The user's unique ID.
 #     #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
-#     pub id: Option<bson::oid::ObjectId>,
+#     pub id: Option<mongodb::oid::ObjectId>,
 # }
 #
 impl<'a> wither::Model<'a> for User {
@@ -68,12 +66,12 @@ impl<'a> wither::Model<'a> for User {
 #     const COLLECTION_NAME: &'static str = "users";
 #
 #     /// Implement the getter for the ID of a model instance.
-#     fn id(&self) -> Option<bson::oid::ObjectId> {
+#     fn id(&self) -> Option<mongodb::oid::ObjectId> {
 #         return self.id.clone();
 #     }
 #
 #     /// Implement the setter for the ID of a model instance.
-#     fn set_id(&mut self, oid: bson::oid::ObjectId) {
+#     fn set_id(&mut self, oid: mongodb::oid::ObjectId) {
 #         self.id = Some(oid);
 #     }
 

--- a/wither/docs/migrations-overview.md
+++ b/wither/docs/migrations-overview.md
@@ -5,9 +5,8 @@ As your system evolves over time, you may find yourself needing to alter the dat
 Migrations are controlled by implementing the [Migrating](./trait.Migrating.html) trait on your `Model`s. This couldn't be more simple, so let's look at an example of an [`IntervalMigration`](./struct.IntervalMigration.html).
 
 ```rust
-# #[macro_use]
-# extern crate bson;
 # extern crate chrono;
+# #[macro_use]
 # extern crate mongodb;
 # extern crate serde;
 # #[macro_use(Serialize, Deserialize)]
@@ -16,19 +15,19 @@ Migrations are controlled by implementing the [Migrating](./trait.Migrating.html
 # #[macro_use(Model)]
 # extern crate wither_derive;
 #
-# use bson::oid::ObjectId;
 # use chrono::offset::TimeZone;
 # use mongodb::{
 #     Client, ThreadedClient,
 #     db::{Database, ThreadedDatabase},
 #     coll::options::IndexModel,
+#     oid::ObjectId,
 # };
 # use wither::prelude::*;
 #
 # #[derive(Serialize, Deserialize, Model)]
 # pub struct User {
 #     #[serde(rename="_id", skip_serializing_if="Option::is_none")]
-#     pub id: Option<bson::oid::ObjectId>,
+#     pub id: Option<mongodb::oid::ObjectId>,
 # }
 #
 impl<'m> Migrating<'m> for User {

--- a/wither/docs/model-derive.md
+++ b/wither/docs/model-derive.md
@@ -27,7 +27,6 @@ Adding indexes to your model's collection is done entirely through the attribute
 
 ```rust
 # #[macro_use]
-# extern crate bson;
 # extern crate mongodb;
 # extern crate serde;
 # #[macro_use(Serialize, Deserialize)]
@@ -44,7 +43,7 @@ Adding indexes to your model's collection is done entirely through the attribute
 struct MyModel {
     // snip ...
     # #[serde(rename="_id", skip_serializing_if="Option::is_none")]
-    # pub id: Option<bson::oid::ObjectId>,
+    # pub id: Option<mongodb::oid::ObjectId>,
 
     /// This field has a unique index on it.
     #[model(index(index_type="dsc", unique="true"))]
@@ -79,7 +78,6 @@ This is optional. Values here simply map field names to `i32` values wrapped in 
 
 ```rust
 # #[macro_use]
-# extern crate bson;
 # extern crate mongodb;
 # extern crate serde;
 # #[macro_use(Serialize, Deserialize)]
@@ -94,7 +92,7 @@ This is optional. Values here simply map field names to `i32` values wrapped in 
 # #[derive(Model, Serialize, Deserialize)]
 # struct MyModel {
     # #[serde(rename="_id", skip_serializing_if="Option::is_none")]
-    # pub id: Option<bson::oid::ObjectId>,
+    # pub id: Option<mongodb::oid::ObjectId>,
 
     // ... other model fields
 

--- a/wither/src/lib.rs
+++ b/wither/src/lib.rs
@@ -1,11 +1,10 @@
 #![cfg_attr(feature="docinclude", feature(external_doc))]
 #![cfg_attr(feature="docinclude", doc(include="../README.md"))]
 
-#[macro_use(doc, bson)]
-pub extern crate bson;
 extern crate chrono;
 #[macro_use]
 extern crate log;
+#[macro_use(doc, bson)]
 pub extern crate mongodb;
 extern crate serde;
 

--- a/wither/src/migration.rs
+++ b/wither/src/migration.rs
@@ -2,9 +2,9 @@
 
 use std::error::Error;
 
-use bson::{Bson, Document};
 use chrono;
 use mongodb::{
+    Bson, Document,
     db::{
         Database,
         ThreadedDatabase,

--- a/wither/tests/fixtures/mod.rs
+++ b/wither/tests/fixtures/mod.rs
@@ -1,6 +1,9 @@
-use bson::{self, Document};
 use chrono::{self, TimeZone};
-use mongodb::coll::options::IndexModel;
+use mongodb::{
+    Document,
+    coll::options::IndexModel,
+    oid::ObjectId,
+};
 use wither::{self, prelude::*};
 
 pub mod fixture;
@@ -14,7 +17,7 @@ pub use self::fixture::Fixture;
 pub struct User {
     /// The user's unique ID.
     #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
-    pub id: Option<bson::oid::ObjectId>,
+    pub id: Option<ObjectId>,
 
     /// The user's unique email.
     pub email: String,
@@ -24,11 +27,11 @@ impl<'a> Model<'a> for User {
 
     const COLLECTION_NAME: &'static str = "users";
 
-    fn id(&self) -> Option<bson::oid::ObjectId> {
+    fn id(&self) -> Option<ObjectId> {
         return self.id.clone();
     }
 
-    fn set_id(&mut self, oid: bson::oid::ObjectId) {
+    fn set_id(&mut self, oid: ObjectId) {
         self.id = Some(oid);
     }
 
@@ -64,7 +67,7 @@ impl<'m> Migrating<'m> for User {
 pub struct UserModelBadMigrations {
     /// The user's unique ID.
     #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
-    pub id: Option<bson::oid::ObjectId>,
+    pub id: Option<ObjectId>,
 
     /// The user's unique email.
     pub email: String,
@@ -74,11 +77,11 @@ impl<'a> Model<'a> for UserModelBadMigrations {
 
     const COLLECTION_NAME: &'static str = "users_bad_migrations";
 
-    fn id(&self) -> Option<bson::oid::ObjectId> {
+    fn id(&self) -> Option<ObjectId> {
         return self.id.clone();
     }
 
-    fn set_id(&mut self, oid: bson::oid::ObjectId) {
+    fn set_id(&mut self, oid: ObjectId) {
         self.id = Some(oid);
     }
 
@@ -116,7 +119,7 @@ impl<'m> Migrating<'m> for UserModelBadMigrations {
 pub struct DerivedModel {
     /// The ID of the model.
     #[serde(rename="_id", skip_serializing_if="Option::is_none")]
-    pub id: Option<bson::oid::ObjectId>,
+    pub id: Option<ObjectId>,
 
     // A field to test base line index options with index of type `asc`.
     #[model(index(
@@ -149,7 +152,7 @@ pub struct DerivedModel {
 pub struct Derived2dModel {
     /// The ID of the model.
     #[serde(rename="_id", skip_serializing_if="Option::is_none")]
-    pub id: Option<bson::oid::ObjectId>,
+    pub id: Option<ObjectId>,
 
     // A field to test index of type `2d`.
     #[model(index(index_type="2d", with(field_2d_filter="asc"), min="-180.0", max="180.0", bits="1"))]
@@ -161,7 +164,7 @@ pub struct Derived2dModel {
 pub struct Derived2dsphereModel {
     /// The ID of the model.
     #[serde(rename="_id", skip_serializing_if="Option::is_none")]
-    pub id: Option<bson::oid::ObjectId>,
+    pub id: Option<ObjectId>,
 
     // A field to test index of type `2dsphere`.
     #[model(index(index_type="2dsphere", sphere_version="3", with(field_2dsphere_filter="asc")))]
@@ -173,7 +176,7 @@ pub struct Derived2dsphereModel {
 pub struct DerivedGeoHaystackModel {
     /// The ID of the model.
     #[serde(rename="_id", skip_serializing_if="Option::is_none")]
-    pub id: Option<bson::oid::ObjectId>,
+    pub id: Option<ObjectId>,
 
     // A field to test index of type `geoHaystack`.
     #[model(index(index_type="geoHaystack", bucket_size="5", with(field_geo_haystack_filter="asc")))]

--- a/wither/tests/model.rs
+++ b/wither/tests/model.rs
@@ -1,8 +1,7 @@
-#[macro_use(doc, bson)]
-extern crate bson;
 extern crate chrono;
 #[macro_use]
 extern crate lazy_static;
+#[macro_use(doc, bson)]
 extern crate mongodb;
 extern crate serde;
 #[macro_use(Serialize, Deserialize)]
@@ -15,8 +14,11 @@ mod fixtures;
 
 use std::error::Error;
 
-use mongodb::coll::options::{FindOneAndUpdateOptions, ReturnDocument};
-use mongodb::db::ThreadedDatabase;
+use mongodb::{
+    Document,
+    coll::options::{FindOneAndUpdateOptions, ReturnDocument},
+    db::ThreadedDatabase,
+};
 use wither::prelude::*;
 
 use fixtures::{
@@ -166,14 +168,14 @@ fn model_sync_should_create_expected_indices_on_collection() {
     let fixture = Fixture::new().with_synced_models().with_empty_collections();
     let db = fixture.get_db();
     let coll = db.collection(User::COLLECTION_NAME);
-    let initial_indices: Vec<bson::Document> = coll.list_indexes()
+    let initial_indices: Vec<Document> = coll.list_indexes()
         .expect("Expected to successfully open indices cursor pre-test.")
         .filter_map(|doc_res| doc_res.ok())
         .collect();
     let initial_indices_len = initial_indices.len();
 
     let _ = User::sync(db.clone()).expect("Expected a successful sync operation.");
-    let mut output_indices: Vec<bson::Document> = coll.list_indexes()
+    let mut output_indices: Vec<Document> = coll.list_indexes()
         .expect("Expected to successfully open indices cursor post-test.")
         .filter_map(|doc_res| doc_res.ok())
         .collect();
@@ -194,14 +196,14 @@ fn model_sync_should_create_expected_indices_on_collection_for_derived_model() {
     let fixture = Fixture::new().with_synced_models().with_empty_collections();
     let db = fixture.get_db();
     let coll = db.collection(DerivedModel::COLLECTION_NAME);
-    let initial_indices: Vec<bson::Document> = coll.list_indexes()
+    let initial_indices: Vec<Document> = coll.list_indexes()
         .expect("Expected to successfully open indices cursor pre-test.")
         .filter_map(|doc_res| doc_res.ok())
         .collect();
     let initial_indices_len = initial_indices.len();
 
     let _ = DerivedModel::sync(db.clone()).expect("Expected a successful sync operation.");
-    let mut output_indices: Vec<bson::Document> = coll.list_indexes()
+    let mut output_indices: Vec<Document> = coll.list_indexes()
         .expect("Expected to successfully open indices cursor post-test.")
         .filter_map(|doc_res| doc_res.ok())
         .collect();
@@ -258,14 +260,14 @@ fn model_sync_should_create_expected_indices_on_collection_for_derived_2d_model(
     let fixture = Fixture::new().with_synced_models().with_empty_collections();
     let db = fixture.get_db();
     let coll = db.collection(Derived2dModel::COLLECTION_NAME);
-    let initial_indices: Vec<bson::Document> = coll.list_indexes()
+    let initial_indices: Vec<Document> = coll.list_indexes()
         .expect("Expected to successfully open indices cursor pre-test.")
         .filter_map(|doc_res| doc_res.ok())
         .collect();
     let initial_indices_len = initial_indices.len();
 
     let _ = Derived2dModel::sync(db.clone()).expect("Expected a successful sync operation.");
-    let mut output_indices: Vec<bson::Document> = coll.list_indexes()
+    let mut output_indices: Vec<Document> = coll.list_indexes()
         .expect("Expected to successfully open indices cursor post-test.")
         .filter_map(|doc_res| doc_res.ok())
         .collect();
@@ -293,14 +295,14 @@ fn model_sync_should_create_expected_indices_on_collection_for_derived_2dsphere_
     let fixture = Fixture::new().with_synced_models().with_empty_collections();
     let db = fixture.get_db();
     let coll = db.collection(Derived2dsphereModel::COLLECTION_NAME);
-    let initial_indices: Vec<bson::Document> = coll.list_indexes()
+    let initial_indices: Vec<Document> = coll.list_indexes()
         .expect("Expected to successfully open indices cursor pre-test.")
         .filter_map(|doc_res| doc_res.ok())
         .collect();
     let initial_indices_len = initial_indices.len();
 
     let _ = Derived2dsphereModel::sync(db.clone()).expect("Expected a successful sync operation.");
-    let mut output_indices: Vec<bson::Document> = coll.list_indexes()
+    let mut output_indices: Vec<Document> = coll.list_indexes()
         .expect("Expected to successfully open indices cursor post-test.")
         .filter_map(|doc_res| doc_res.ok())
         .collect();
@@ -328,14 +330,14 @@ fn model_sync_should_create_expected_indices_on_collection_for_derived_2dsphere_
 //     let fixture = Fixture::new().with_synced_models().with_empty_collections();
 //     let db = fixture.get_db();
 //     let coll = db.collection(DerivedGeoHaystackModel::COLLECTION_NAME);
-//     let initial_indices: Vec<bson::Document> = coll.list_indexes()
+//     let initial_indices: Vec<Document> = coll.list_indexes()
 //         .expect("Expected to successfully open indices cursor pre-test.")
 //         .filter_map(|doc_res| doc_res.ok())
 //         .collect();
 //     let initial_indices_len = initial_indices.len();
 
 //     let _ = DerivedGeoHaystackModel::sync(db.clone()).expect("Expected a successful sync operation.");
-//     let mut output_indices: Vec<bson::Document> = coll.list_indexes()
+//     let mut output_indices: Vec<Document> = coll.list_indexes()
 //         .expect("Expected to successfully open indices cursor post-test.")
 //         .filter_map(|doc_res| doc_res.ok())
 //         .collect();

--- a/wither_derive/Cargo.toml
+++ b/wither_derive/Cargo.toml
@@ -9,13 +9,12 @@ license = "Apache-2.0"
 name = "wither_derive"
 readme = "README.md"
 repository = "https://github.com/thedodd/wither"
-version = "0.6.1"
+version = "0.6.2"
 
 [lib]
 proc-macro = true
 
 [dependencies]
-bson = "0.12"
 Inflector = "0.11"
 mongodb = "0.3"
 proc-macro2 = "0.4"

--- a/wither_derive/src/lib.rs
+++ b/wither_derive/src/lib.rs
@@ -2,9 +2,8 @@
 
 #![recursion_limit="200"]
 
-#[macro_use]
-extern crate bson;
 extern crate inflector;
+#[macro_use]
 extern crate mongodb;
 extern crate proc_macro;
 extern crate proc_macro2;
@@ -49,12 +48,12 @@ pub fn proc_macro_derive_model(input: TokenStream) -> TokenStream {
             const COLLECTION_NAME: &'static str = #collection_name;
 
             /// Get a cloned copy of this instance's ID.
-            fn id(&self) -> ::std::option::Option<::bson::oid::ObjectId> {
+            fn id(&self) -> ::std::option::Option<mongodb::oid::ObjectId> {
                 self.id.clone()
             }
 
             /// Set this instance's ID.
-            fn set_id(&mut self, oid: ::bson::oid::ObjectId) {
+            fn set_id(&mut self, oid: mongodb::oid::ObjectId) {
                 self.id = Some(oid);
             }
 

--- a/wither_derive/src/model_field.rs
+++ b/wither_derive/src/model_field.rs
@@ -1,8 +1,10 @@
 use std::fmt::Display;
 use std::str::FromStr;
 
-use bson::Document;
-use mongodb::coll::options::{IndexModel, IndexOptions};
+use mongodb::{
+    Document,
+    coll::options::{IndexModel, IndexOptions},
+};
 use syn;
 
 use msg;

--- a/wither_derive/src/tokens.rs
+++ b/wither_derive/src/tokens.rs
@@ -1,8 +1,10 @@
 use quote::ToTokens;
 use proc_macro2::TokenStream;
 
-use bson::Document;
-use mongodb::coll::options::{IndexModel, IndexOptions};
+use mongodb::{
+    Bson, Document,
+    coll::options::{IndexModel, IndexOptions},
+};
 
 pub struct Indexes(pub Vec<IndexModel>);
 
@@ -71,8 +73,8 @@ impl ToTokens for Indexes {
 fn build_index_keys(doc: &Document) -> TokenStream {
     let key_vals = doc.iter().map(|(key, val)| {
         match val { // Currently, we will only be returning fields which are i32, i64, or string.
-            bson::Bson::String(s) => quote!(#key: #s),
-            bson::Bson::I32(int32) => quote!(#key: #int32),
+            Bson::String(s) => quote!(#key: #s),
+            Bson::I32(int32) => quote!(#key: #int32),
             _ => panic!("Developer error. Found an unexpected index document val of type {:?}. This is a bug within the wither framework. Please open an issue here: https://github.com/thedodd/wither/issues/new", val),
         }
     }).collect::<Vec<TokenStream>>();
@@ -104,7 +106,7 @@ fn option_to_tokens_for_weights(doc_opt: Option<Document>) -> TokenStream {
         Some(doc) => {
             let key_vals = doc.iter().map(|(key, val)| {
                 match val { // Weights can only be mapped to an i32 in this system.
-                    bson::Bson::I32(int32) => quote!(#key: #int32),
+                    Bson::I32(int32) => quote!(#key: #int32),
                     _ => panic!("Developer error. Found unexpected type for index weights value {:?}. This is a bug within the wither framework. Please open an issue here: https://github.com/thedodd/wither/issues/new", val),
                 }
             }).collect::<Vec<TokenStream>>();

--- a/wither_tests/Cargo.toml
+++ b/wither_tests/Cargo.toml
@@ -6,7 +6,6 @@ version = "0.0.0"
 [dependencies]
 
 [dev-dependencies]
-bson = "0.12"
 compiletest_rs = "0.3"
 mongodb = "0.3"
 serde = "1"

--- a/wither_tests/tests/compile-fail/incorrect-id-serde-attr-value-id.rs
+++ b/wither_tests/tests/compile-fail/incorrect-id-serde-attr-value-id.rs
@@ -1,6 +1,5 @@
-#[macro_use]
-extern crate bson;
 extern crate compiletest_rs as compiletest;
+#[macro_use]
 extern crate mongodb;
 extern crate serde;
 #[macro_use(Serialize, Deserialize)]
@@ -14,7 +13,7 @@ use wither::Model;
 #[derive(Serialize, Deserialize, Model)]
 struct BadModel {
     #[serde(rename="_bad", skip_serializing_if="Option::is_none")]
-    id: Option<bson::oid::ObjectId>,
+    id: Option<mongodb::oid::ObjectId>,
 }
 //~^^^^^ ERROR: proc-macro derive panicked
 //~| HELP: A `Model`'s 'id' field must have a serde `rename` attribute with a value of `"_id"`.

--- a/wither_tests/tests/compile-fail/incorrect-id-serde-attr-value-skip.rs
+++ b/wither_tests/tests/compile-fail/incorrect-id-serde-attr-value-skip.rs
@@ -1,6 +1,5 @@
-#[macro_use]
-extern crate bson;
 extern crate compiletest_rs as compiletest;
+#[macro_use]
 extern crate mongodb;
 extern crate serde;
 #[macro_use(Serialize, Deserialize)]
@@ -14,7 +13,7 @@ use wither::Model;
 #[derive(Serialize, Deserialize, Model)]
 struct BadModel {
     #[serde(rename="_id", skip_serializing_if="Option::is_some")]
-    id: Option<bson::oid::ObjectId>,
+    id: Option<mongodb::oid::ObjectId>,
 }
 //~^^^^^ ERROR: proc-macro derive panicked
 //~| HELP: A `Model`'s 'id' field must have a serde `skip_serializing_if` attribute with a value of `"Option::is_none"`.

--- a/wither_tests/tests/compile-fail/missing-id-field.rs
+++ b/wither_tests/tests/compile-fail/missing-id-field.rs
@@ -1,6 +1,5 @@
-#[macro_use]
-extern crate bson;
 extern crate compiletest_rs as compiletest;
+#[macro_use]
 extern crate mongodb;
 extern crate serde;
 #[macro_use(Serialize, Deserialize)]

--- a/wither_tests/tests/compile-fail/missing-id-serde-attrs.rs
+++ b/wither_tests/tests/compile-fail/missing-id-serde-attrs.rs
@@ -1,6 +1,5 @@
-#[macro_use]
-extern crate bson;
 extern crate compiletest_rs as compiletest;
+#[macro_use]
 extern crate mongodb;
 extern crate serde;
 #[macro_use(Serialize, Deserialize)]
@@ -13,7 +12,7 @@ use wither::Model;
 
 #[derive(Serialize, Deserialize, Model)]
 struct BadModel {
-    id: Option<bson::oid::ObjectId>,
+    id: Option<mongodb::oid::ObjectId>,
 }
 //~^^^^ ERROR: proc-macro derive panicked
 //~| HELP: A `Model` struct must have a field named `id`, and it must have the following attribute: `#[serde(rename="_id", skip_serializing_if="Option::is_none")]`.

--- a/wither_tests/tests/compile-fail/model-no-fields.rs
+++ b/wither_tests/tests/compile-fail/model-no-fields.rs
@@ -1,6 +1,5 @@
-#[macro_use]
-extern crate bson;
 extern crate compiletest_rs as compiletest;
+#[macro_use]
 extern crate mongodb;
 extern crate serde;
 #[macro_use(Serialize, Deserialize)]

--- a/wither_tests/tests/compile-fail/struct-attr-collection_name-invalid-type.rs
+++ b/wither_tests/tests/compile-fail/struct-attr-collection_name-invalid-type.rs
@@ -1,6 +1,5 @@
-#[macro_use]
-extern crate bson;
 extern crate compiletest_rs as compiletest;
+#[macro_use]
 extern crate mongodb;
 extern crate serde;
 #[macro_use(Serialize, Deserialize)]
@@ -15,7 +14,7 @@ use wither::Model;
 #[model(collection_name=true)]
 struct BadModel {
     #[serde(rename="_id", skip_serializing_if="Option::is_none")]
-    id: Option<bson::oid::ObjectId>,
+    id: Option<mongodb::oid::ObjectId>,
 }
 //~^^^^^^ ERROR: proc-macro derive panicked
 //~| HELP: Only string literals are supported as named values in `Model` attributes.

--- a/wither_tests/tests/compile-fail/struct-attr-collection_name-zero-length.rs
+++ b/wither_tests/tests/compile-fail/struct-attr-collection_name-zero-length.rs
@@ -1,6 +1,5 @@
-#[macro_use]
-extern crate bson;
 extern crate compiletest_rs as compiletest;
+#[macro_use]
 extern crate mongodb;
 extern crate serde;
 #[macro_use(Serialize, Deserialize)]
@@ -15,7 +14,7 @@ use wither::Model;
 #[model(collection_name="")]
 struct BadModel {
     #[serde(rename="_id", skip_serializing_if="Option::is_none")]
-    id: Option<bson::oid::ObjectId>,
+    id: Option<mongodb::oid::ObjectId>,
 }
 //~^^^^^^ ERROR: proc-macro derive panicked
 //~| HELP: The `Model` struct attribute 'collection_name' may not have a zero-length value.

--- a/wither_tests/tests/compile-fail/struct-attr-missing-serde-derivations.rs
+++ b/wither_tests/tests/compile-fail/struct-attr-missing-serde-derivations.rs
@@ -1,6 +1,5 @@
-#[macro_use]
-extern crate bson;
 extern crate compiletest_rs as compiletest;
+#[macro_use]
 extern crate mongodb;
 extern crate serde;
 #[macro_use(Serialize, Deserialize)]
@@ -15,7 +14,7 @@ use mongodb::coll::options::IndexModel;
 #[derive(Model)]
 #[model(skip_serde_checks)]
 struct BadModel {
-    id: Option<bson::oid::ObjectId>,
+    id: Option<mongodb::oid::ObjectId>,
 }
-//~^^^^^ 15:10: 15:15: the trait bound `BadModel: serde::Deserialize<'a>` is not satisfied [E0277]
-//~^^^^^^ 15:10: 15:15: the trait bound `BadModel: serde::Serialize` is not satisfied [E0277]
+//~^^^^^ the trait bound `BadModel: serde::Deserialize<'a>` is not satisfied [E0277]
+//~^^^^^^ the trait bound `BadModel: serde::Serialize` is not satisfied [E0277]

--- a/wither_tests/tests/compile-fail/struct-attr-unrecognized.rs
+++ b/wither_tests/tests/compile-fail/struct-attr-unrecognized.rs
@@ -1,6 +1,5 @@
-#[macro_use]
-extern crate bson;
 extern crate compiletest_rs as compiletest;
+#[macro_use]
 extern crate mongodb;
 extern crate serde;
 #[macro_use(Serialize, Deserialize)]
@@ -15,7 +14,7 @@ use wither::Model;
 #[model(bad_attr="val")]
 struct BadModel {
     #[serde(rename="_id", skip_serializing_if="Option::is_none")]
-    id: Option<bson::oid::ObjectId>,
+    id: Option<mongodb::oid::ObjectId>,
 }
 //~^^^^^^ ERROR: proc-macro derive panicked
 //~| HELP: Unrecognized struct-level `Model` attribute 'bad_attr'.

--- a/wither_tests/tests/modelgen.rs
+++ b/wither_tests/tests/modelgen.rs
@@ -1,6 +1,5 @@
-#[macro_use]
-extern crate bson;
 extern crate compiletest_rs as compiletest;
+#[macro_use]
 extern crate mongodb;
 extern crate serde;
 #[macro_use(Serialize, Deserialize)]
@@ -9,9 +8,8 @@ extern crate wither;
 #[macro_use(Model)]
 extern crate wither_derive;
 
-use bson::Document;
 use wither::prelude::*;
-use mongodb::coll::options::IndexModel;
+use mongodb::{Document, coll::options::IndexModel};
 
 /// This model tests all of the major code generation bits.
 ///
@@ -22,7 +20,7 @@ use mongodb::coll::options::IndexModel;
 struct DerivedModel {
     /// The ID of the model.
     #[serde(rename="_id", skip_serializing_if="Option::is_none")]
-    pub id: Option<bson::oid::ObjectId>,
+    pub id: Option<mongodb::oid::ObjectId>,
 
     // A field to test base line index options with index of type `asc`.
     #[model(index(
@@ -71,7 +69,7 @@ struct DerivedModel {
 #[model(wc_replication="2", wc_timeout="300", wc_journaling="false", wc_fsync="true")]
 struct SecondModel {
     #[serde(rename="_id", skip_serializing_if="Option::is_none")]
-    id: Option<bson::oid::ObjectId>,
+    id: Option<mongodb::oid::ObjectId>,
 }
 
 #[test]

--- a/wither_tests/tests/run-pass/derive-model.rs
+++ b/wither_tests/tests/run-pass/derive-model.rs
@@ -1,6 +1,5 @@
-#[macro_use]
-extern crate bson;
 extern crate compiletest_rs as compiletest;
+#[macro_use]
 extern crate mongodb;
 extern crate serde;
 #[macro_use(Serialize, Deserialize)]
@@ -17,7 +16,7 @@ use mongodb::coll::options::IndexModel;
 struct ValidDataModel0 {
     /// The ID of the model.
     #[serde(rename="_id", skip_serializing_if="Option::is_none")]
-    id: Option<bson::oid::ObjectId>,
+    id: Option<mongodb::oid::ObjectId>,
 
     /// A field to test base line index options & bool fields with `true`.
     #[model(index(


### PR DESCRIPTION
This means that we should no longer run into issues with the bson crate
as it is now re-exported from the mongodb crate.