### PR TITLE
Handle a cursor bug related to getMore on non-existing coll.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ struct User {
 }
 
 fn main() {
-    // Create a user.
+    // Get a database connection & sync your model.
     let db = mongodb::Client::with_uri("mongodb://localhost:27017/").unwrap().db("mydb");
+    User::sync(db.clone()).unwrap();
+
+    // Create a user.
     let mut me = User{id: None, email: "my.email@example.com".to_string()};
     me.save(db.clone(), None);
 

--- a/wither/tests/model.rs
+++ b/wither/tests/model.rs
@@ -86,8 +86,7 @@ fn model_find_should_find_all_instances_of_model_with_no_filter_or_options() {
     let users_from_db = User::find(db.clone(), None, None)
         .expect("Expected a successful lookup.");
 
-    assert_eq!((&users_from_db).len(), 1);
-    // assert!((&users_from_db).len() > 0);
+    assert_eq!(users_from_db.len(), 1);
 }
 
 #[test]
@@ -101,9 +100,30 @@ fn model_find_should_find_instances_of_model_matching_filter() {
     let users_from_db = User::find(db.clone(), Some(doc), None)
         .expect("Expected a successful lookup.");
 
-    assert_eq!((&users_from_db).len(), 1);
+    assert_eq!(users_from_db.len(), 1);
     assert_eq!(&users_from_db[0].id, &user.id);
     assert_eq!(&users_from_db[0].email, &user.email);
+}
+
+#[test]
+fn model_find_should_return_empty_vec_where_collection_is_empty() {
+    let fixture = Fixture::new().with_dropped_database().with_synced_models();
+    let db = fixture.get_db();
+    let users_from_db = User::find(db.clone(), None, None)
+        .expect("Expected a successful lookup.");
+
+    assert_eq!(users_from_db.len(), 0);
+}
+
+#[test]
+#[should_panic]
+fn model_find_should_return_empty_vec_where_collection_is_empty_and_not_synced() {
+    let fixture = Fixture::new().with_dropped_database();
+    let db = fixture.get_db();
+    let users_from_db = User::find(db.clone(), None, None)
+        .expect("Expected a successful lookup.");
+
+    assert_eq!(users_from_db.len(), 0);
 }
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This commit adds two tests which are intended to isolate a bug related
to a spurious `DecodeError` mentioned over in #33.

### todo
- [ ] update cursor-based methods to only call `drain_current_batch` if `cursor.has_next()`. This will circumvent a bug in the mongo driver.
- [x] open issue for the bug in the mongo driver mentioned above. The problem is here: https://github.com/mongodb-labs/mongo-rust-driver-prototype/blob/master/src/cursor.rs#L144 The code is attempting to extract error documents based on the key `errmsg`, but it looks like the server is returning errors with `$err`.

Closes #33
Related to mongodb-labs/mongo-rust-driver-prototype#312