### PR TITLE
Support models which have generics.

### DIFF
--- a/wither_derive/src/model.rs
+++ b/wither_derive/src/model.rs
@@ -8,6 +8,7 @@ use msg;
 /// A meta representation of the `Model` derivation target.
 pub(crate) struct MetaModel {
     ident: syn::Ident,
+    generics: syn::Generics,
     struct_fields: syn::FieldsNamed,
     struct_data: MetaModelStructData,
     field_data: MetaModelFieldData,
@@ -18,6 +19,7 @@ impl MetaModel {
     pub fn new(input: DeriveInput) -> Self {
         // The target's ident.
         let ident = input.ident;
+        let generics = input.generics;
 
         // Extract struct data. We only support model derivation on structs.
         let struct_fields = match input.data {
@@ -32,7 +34,7 @@ impl MetaModel {
         let struct_data = MetaModelStructData::new(input.attrs.as_slice(), &ident);
         let field_data = MetaModelFieldData::new(&struct_fields);
 
-        MetaModel{ident, struct_fields, struct_data, field_data}
+        MetaModel{ident, generics, struct_fields, struct_data, field_data}
     }
 
     /// The collection name to be used for this model.
@@ -110,6 +112,11 @@ impl MetaModel {
     /// The target struct's ident.
     pub fn struct_name(&self) -> &syn::Ident {
         &self.ident
+    }
+
+    /// The target struct's generics.
+    pub fn generics(&self) -> &syn::Generics {
+        &self.generics
     }
 
     /// The write replication settings for this model. Defaults to `1`.

--- a/wither_tests/tests/compile-fail/struct-attr-missing-serde-derivations.rs
+++ b/wither_tests/tests/compile-fail/struct-attr-missing-serde-derivations.rs
@@ -16,5 +16,5 @@ use mongodb::coll::options::IndexModel;
 struct BadModel {
     id: Option<mongodb::oid::ObjectId>,
 }
-//~^^^^^ the trait bound `BadModel: serde::Deserialize<'a>` is not satisfied [E0277]
+//~^^^^^ the trait bound `BadModel: serde::Deserialize<'_de>` is not satisfied [E0277]
 //~^^^^^^ the trait bound `BadModel: serde::Serialize` is not satisfied [E0277]


### PR DESCRIPTION
To support models like the following struct,

```rust
#[derive(Debug, Serialize, Deserialize, Model)]
struct Person<'a> {
    #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
    id: Option<ObjectId>,
    name: Cow<'a, str>
}
```