### PR TITLE
Use the full path of IndexModel when sending code back to compiler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The only net-new item being added here is that now, within `#[model(index())]`, 
 
 **It is my sincere hope** that this is the last breaking change I will need to make to this crate before promoting this crate to a `1.0.0` release. Let's hope! Please let me know if there are any issues you have with these updates.
 
+#### 0.8.1 (pending)
+
+- In order to avoid writing `use mongodb::coll::options::IndexModel` explicitly, use the full path of `IndexModel` when sending code back to compiler.
+
 ## 0.7
 Minimal changes per this release. The main issue being addressed here is [#20](https://github.com/thedodd/wither/issues/20). It is arguable that this is just a bug fix, but the interface for `Model.update` has changed enough with these updates that a minor version increment is merited.
 

--- a/wither_derive/src/lib.rs
+++ b/wither_derive/src/lib.rs
@@ -57,7 +57,7 @@ pub fn proc_macro_derive_model(input: TokenStream) -> TokenStream {
             }
 
             /// All indexes currently on this model.
-            fn indexes() -> Vec<IndexModel> {
+            fn indexes() -> Vec<mongodb::coll::options::IndexModel> {
                 #indexes
             }
 


### PR DESCRIPTION
Always explicitly using `mongodb::coll::options::IndexModel` is annoying. So I changed the output code `fn indexes() -> Vec<IndexModel>` to `fn indexes() -> Vec<mongodb::coll::options::IndexModel>`.