### PR TITLE
Replace redundant trait bounds with Model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,9 +1191,9 @@ checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
 
 [[package]]
 name = "scopeguard"
@@ -1242,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
+checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1370,9 +1370,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1416,12 +1416,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi",
  "winapi",
 ]
 
@@ -1657,9 +1656,9 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ An ODM for MongoDB built on the official <a href="https://github.com/mongodb/mon
 </div>
 </br>
 
-The primary goal of this project is to provide a simple, sane & predictable interface into MongoDB based on data models. If at any point this system might get in your way, you have direct access to the underlying driver. This project is tested against MongoDB `3.6`, `4.0`, `4.2` & `4.4`.
+The primary goal of this project is to provide a simple, sane & predictable interface into MongoDB based on data models. If at any point this system might get in your way, you have direct access to the underlying driver. This project is tested against MongoDB `3.6`, `4.0`, `4.2`, `4.4` & `5.0`.
 
 **GREAT NEWS!** Wither is now based on the official [MongoDB Rust driver](https://github.com/mongodb/mongo-rust-driver). Thanks to advancements in the driver, Wither is now fully asynchronous. Simply mirroring the features of the underlying MongoDB driver, Wither supports the following runtimes:
 - `tokio-runtime` (default) activates [the tokio runtime](tokio.rs/).

--- a/wither/src/cursor.rs
+++ b/wither/src/cursor.rs
@@ -10,12 +10,11 @@ use crate::Model;
 /// A cursor of model documents.
 pub struct ModelCursor<T: Model> {
     cursor: Cursor<T>,
-    marker: std::marker::PhantomData<T>,
 }
 
 impl<T: Model> ModelCursor<T> {
     pub(crate) fn new(cursor: Cursor<T>) -> Self {
-        Self { cursor, marker: std::marker::PhantomData }
+        Self { cursor }
     }
 }
 

--- a/wither/src/cursor.rs
+++ b/wither/src/cursor.rs
@@ -3,18 +3,17 @@ use std::task::{Context, Poll};
 
 use futures::stream::Stream;
 use mongodb::Cursor;
-use serde::de::DeserializeOwned;
 
 use crate::error::{Result, WitherError};
 use crate::Model;
 
 /// A cursor of model documents.
-pub struct ModelCursor<T: DeserializeOwned + Unpin + Send + Sync> {
+pub struct ModelCursor<T: Model> {
     cursor: Cursor<T>,
     marker: std::marker::PhantomData<T>,
 }
 
-impl<T: Model + DeserializeOwned + Unpin + Send + Sync> ModelCursor<T> {
+impl<T: Model> ModelCursor<T> {
     pub(crate) fn new(cursor: Cursor<T>) -> Self {
         Self { cursor, marker: std::marker::PhantomData }
     }
@@ -22,9 +21,9 @@ impl<T: Model + DeserializeOwned + Unpin + Send + Sync> ModelCursor<T> {
 
 // Impl Unpin on this container as we do not care about this container staying pinned,
 // only the underlying `Cursor` needs to remain pinned while we poll from this vantage point.
-impl<T: DeserializeOwned + Unpin + Send + Sync> Unpin for ModelCursor<T> {}
+impl<T: Model> Unpin for ModelCursor<T> {}
 
-impl<T: Model + DeserializeOwned + Unpin + Send + Sync> Stream for ModelCursor<T> {
+impl<T: Model> Stream for ModelCursor<T> {
     type Item = Result<T>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/wither/src/model.rs
+++ b/wither/src/model.rs
@@ -34,6 +34,7 @@ const MONGO_DIFF_INDEX_BLACKLIST: [&str; 3] = ["v", "ns", "key"];
 #[async_trait]
 pub trait Model
 where
+    // Unpin + Send + Sync are required to create a mongodb Cursor for the Model.
     Self: Serialize + DeserializeOwned + Unpin + Send + Sync,
 {
     /// The name of the collection where this model's data is stored.


### PR DESCRIPTION
This is as discussed in #89.

I replaced the bounds of the form `Model + X` with just `Model`. In the `Model` trait I wrote a sentence of documentation explaining why the additional trait bounds are needed.

In the `ModelCursor` struct, instead of writing out the bounds required for `Cursor`, I restricted the whole struct to `Model`. That made sense to me, because a `ModelCursor` seems to be designed to be used with a `Model`.

I also removed the `PhantomData` from `ModelCursor`, since the generic type `T` is now used in the `Cursor`.

I additionally added a few characters of documentation stating that we now also test against mongodb 5, and I ran `cargo update`.